### PR TITLE
Fix CSS loading by using href attribute

### DIFF
--- a/sample.html
+++ b/sample.html
@@ -1,4 +1,4 @@
-<link type="text/css" src="https://dwi8drzf3c87f.cloudfront.net/before-after/before-after.min.css" rel="stylesheet">
+<link type="text/css" href="https://dwi8drzf3c87f.cloudfront.net/before-after/before-after.min.css" rel="stylesheet">
 
 <div class="ba-slider">
    <img src="http://i.imgur.com/BIHN8KQ.jpg">


### PR DESCRIPTION
Changed attribute from `src` to `href` to correctly load CSS file. The button for the slider is missing, presumably due to older CSS stored on cloudfront.
